### PR TITLE
[DOCS] Adds form of deep links to documentation

### DIFF
--- a/Documentation/InstallAndSetup/Index.rst
+++ b/Documentation/InstallAndSetup/Index.rst
@@ -22,3 +22,12 @@ Include the TypoScript Template for Deeplinking Support
 In order to enable the *Edit in CMS* deeplinking button, you must include the static template "Siteimprove Deeplinking Tags" in your site's root template. This will include a couple of new meta tags in your page header allowing Siteimprove to generate the button link. (Remember to clear the cache afterwards.)
 
 When you run TYPO3 in *Development* context, you will have access to a second static template called "Siteimprove Deeplinking Development Tag". Including this static template will insert a meta tag named "editingPage" on your pages for testing and debugging purposes. It contains the full deeplinking URL similar to the one that will be used when you click the *Edit in CMS* deeplinking button within the *Siteimprove Intelligence Platform*.
+
+A deep link to a page is of the following form:
+
+	https://example.com/typo3/index.php?tx_siteimprove_goto=page:{page_uid}:{language_uid}
+
+Whereas the language_uid is optional and defaults to 0. Example links could look like this:
+
+	https://example.com/typo3/index.php?tx_siteimprove_goto=page:42
+	https://example.com/typo3/index.php?tx_siteimprove_goto=page:42:1

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ The following commands are available in the Extension Manager settings.
 
     token - The API token to use for Siteimprove. If none is provided the default kicks in
 
+## Deep Linking
+
+A deep link to a page is of the following form:
+
+    https://example.com/typo3/index.php?tx_siteimprove_goto=page:{page_uid}:{language_uid}
+    
+Whereas the `language_uid` is optional and defaults to `0`. Example links could look like this:
+
+    https://example.com/typo3/index.php?tx_siteimprove_goto=page:42
+    https://example.com/typo3/index.php?tx_siteimprove_goto=page:42:1
+
+## Documentation
+
 For all kind of documentation which covers install to how to develop the extension:
 
 [Local Documentation](Documentation/Index.rst)


### PR DESCRIPTION
I had to dig into the extension code to find this information, so I thought it would be nice to have it in the documentation