### PR TITLE
[TASK] Respect Site Configuration for TYPO3 9 LTS

### DIFF
--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -52,8 +52,14 @@ class PageRenderer implements SingletonInterface
                 $url = '';
                 $pageId = (int)$GLOBALS['SOBE']->id;
                 if ($pageId > 0) {
-                    $rootLine = BackendUtility::BEgetRootLine($pageId);
-                    $domain = BackendUtility::firstDomainRecord($rootLine);
+                    if (version_compare(TYPO3_branch, '9.5', '<')) {
+                        $rootLine = BackendUtility::BEgetRootLine($pageId);
+                        $domain = BackendUtility::firstDomainRecord($rootLine);
+                    } else {
+                        $siteFinder = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Site\SiteFinder::class);
+                        $site = $siteFinder->getSiteByPageId($pageId);
+                        $domain = $site->getBase()->getHost();
+                    }
                     $eidUrl = $this->getEidUrl($pageId, $domain);
 
                     $debugScript = '';


### PR DESCRIPTION
To fetch the correct domain record for TYPO3 versions higher than 9 LTS, the Site Configuration should be used.