### PR TITLE
[BUGFIX] Prevent SiteNotFoundException in page module

### DIFF
--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -61,6 +61,9 @@ class PageRenderer implements SingletonInterface
 
                 if ($pageId > 0) {
                     $domain = CompatibilityUtility::getFirstDomainInRootline($pageId);
+                    if (!$domain) {
+                        return;
+                    }
 
                     $debugScript = '';
                     if ($debugMode === true) {

--- a/Classes/Utility/CompatibilityUtility.php
+++ b/Classes/Utility/CompatibilityUtility.php
@@ -103,7 +103,7 @@ class CompatibilityUtility
      * Returns the first available domain in the rootline from $pageId
      *
      * @param $pageId
-     * @return string
+     * @return string|null
      */
     public static function getFirstDomainInRootline($pageId)
     {
@@ -115,9 +115,14 @@ class CompatibilityUtility
 
         /** @var SiteFinder $siteFinder */
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
-        $site = $siteFinder->getSiteByPageId($pageId);
 
-        return $site->getBase()->getHost();
+        try {
+            $site = $siteFinder->getSiteByPageId($pageId);
+            return $site->getBase()->getHost();
+        } catch (SiteNotFoundException $e) {
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
When accessing a page with the page module that is not inside
a configured site you currently get an exception:

No site found in root line of page xxx

This Exception is now catched and the inclusion of the
Siteimporve JS in the page module is skipped when no
domain is available.