### PR TITLE
[BUGFIX] Prevent SiteNotFoundException in page module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,11 @@ jobs:
           - typo3-version: "^7.6"
             database-image: mysql:5.7
           - typo3-version: "^8.7"
-            database-image: mariadb:latest
+            database-image: mariadb:10.5.6
           - typo3-version: "^9.5"
-            database-image: mariadb:latest
+            database-image: mariadb:10.5.6
           - typo3-version: "^10.4"
-            database-image: mariadb:latest
+            database-image: mariadb:10.5.6
         exclude:
           - typo3-version: "^7.6"
             composer-version: v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,12 +222,12 @@ jobs:
       - name: Run unit tests
         # Environment variable can be removed when TYPO3 v7 support ends
         env:
-          TYPO3_PATH_ROOT: /home/runner/work/pxa_siteimprove/pxa_siteimprove/.Build/public
+          TYPO3_PATH_ROOT: ${{ github.workspace }}/.Build/public
         run: composer ci:tests:unit
 
       - name: Run functional tests
         env:
-          TYPO3_PATH_ROOT: /home/runner/work/pxa_siteimprove/pxa_siteimprove/.Build/public
+          TYPO3_PATH_ROOT: ${{ github.workspace }}/.Build/public
           typo3DatabaseHost: 127.0.0.1
           typo3DatabasePort: ${{ job.services.mysql.ports['3306'] }}
           typo3DatabaseName: typo3

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -61,6 +61,9 @@ class PageRenderer implements SingletonInterface
 
                 if ($pageId > 0) {
                     $domain = CompatibilityUtility::getFirstDomainInRootline($pageId);
+                    if (!$domain) {
+                        return;
+                    }
 
                     $debugScript = '';
                     if ($debugMode === true) {

--- a/Classes/Utility/CompatibilityUtility.php
+++ b/Classes/Utility/CompatibilityUtility.php
@@ -103,7 +103,7 @@ class CompatibilityUtility
      * Returns the first available domain in the rootline from $pageId
      *
      * @param $pageId
-     * @return string
+     * @return string|null
      */
     public static function getFirstDomainInRootline($pageId)
     {
@@ -115,9 +115,14 @@ class CompatibilityUtility
 
         /** @var SiteFinder $siteFinder */
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
-        $site = $siteFinder->getSiteByPageId($pageId);
 
-        return $site->getBase()->getHost();
+        try {
+            $site = $siteFinder->getSiteByPageId($pageId);
+            return $site->getBase()->getHost();
+        } catch (SiteNotFoundException $e) {
+        }
+
+        return null;
     }
 
     /**

--- a/Classes/Utility/CompatibilityUtility.php
+++ b/Classes/Utility/CompatibilityUtility.php
@@ -120,9 +120,8 @@ class CompatibilityUtility
             $site = $siteFinder->getSiteByPageId($pageId);
             return $site->getBase()->getHost();
         } catch (SiteNotFoundException $e) {
+            return null;
         }
-
-        return null;
     }
 
     /**

--- a/Tests/Functional/Controller/AjaxBackendControllerTest.php
+++ b/Tests/Functional/Controller/AjaxBackendControllerTest.php
@@ -19,7 +19,7 @@ class AjaxBackendControllerTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $rootPath = '/home/runner/work/pxa_siteimprove/pxa_siteimprove/';
+        $rootPath = realpath(__DIR__ . '/../../../') . '/';
 
         if (CompatibilityUtility::typo3VersionIsLessThan('8.0')) {
             $GLOBALS['TT'] = new NullTimeTracker();


### PR DESCRIPTION
When accessing a page with the page module that is not inside
a configured site you currently get an exception:

No site found in root line of page xxx.

This Exception is now catched and the inclusion of the
Siteimporve JS in the page module is skipped when no
domain is available.